### PR TITLE
working on heroku prebuild

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,12 @@
   "name": "my-project",
   "scripts": {
     "start": "node server/server.js",
-    "heroku-postbuild": "webpack --config webpack.prod.js",
-    "dev": "webpack-dev-server --hot --port 8080 --host 127.0.0.1 --open --config webpack.dev.js",
+    "heroku-prebuild":
+      "export NPM_CONFIG_PRODUCTION=false; export NODE_ENV=development; npm install",
+    "heroku-postbuild":
+      "export NPM_CONFIG_PRODUCTION=true; export NODE_ENV=production; webpack --config webpack.prod.js",
+    "dev":
+      "webpack-dev-server --hot --port 8080 --host 127.0.0.1 --open --config webpack.dev.js",
     "build": "webpack --config webpack.prod.js",
     "compile": "webpack -p --config webpack.dev.js",
     "production": "grunt deploy"
@@ -16,16 +20,6 @@
   "version": "1.0.0",
   "dependencies": {
     "axios": "^0.16.2",
-    "babel-cli": "^6.24.1",
-    "babel-core": "^6.25.0",
-    "babel-eslint": "^7.2.3",
-    "babel-loader": "^7.1.1",
-    "babel-plugin-transform-decorators-legacy": "^1.3.4",
-    "babel-plugin-transform-object-rest-spread": "^6.26.0",
-    "babel-preset-env": "^1.6.0",
-    "babel-preset-es2015": "^6.24.1",
-    "babel-preset-latest": "^6.22.0",
-    "babel-preset-react": "^6.24.1",
     "bluebird": "^3.5.0",
     "body-parser": "^1.18.2",
     "compression-webpack-plugin": "^1.0.0",
@@ -58,13 +52,24 @@
     "request": "^2.83.0",
     "sass-loader": "^6.0.6",
     "spotify-web-api-js": "^0.22.1",
-    "styled-components": "^2.2.1",
+    "styled-components": "^2.2.1"
+  },
+  "devDependencies": {
     "webpack-dev-middleware": "^1.10.0",
     "file-loader": "^1.1.5",
     "uglifyjs-webpack-plugin": "^0.4.6",
     "webpack-dev-server": "^2.6.1",
     "webpack": "^2.7.0",
-    "webpack-merge": "^4.1.0"
-  },
-  "devDependencies": {}
+    "webpack-merge": "^4.1.0",
+    "babel-cli": "^6.24.1",
+    "babel-core": "^6.25.0",
+    "babel-eslint": "^7.2.3",
+    "babel-loader": "^7.1.1",
+    "babel-plugin-transform-decorators-legacy": "^1.3.4",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
+    "babel-preset-env": "^1.6.0",
+    "babel-preset-es2015": "^6.24.1",
+    "babel-preset-latest": "^6.22.0",
+    "babel-preset-react": "^6.24.1"
+  }
 }


### PR DESCRIPTION
added heroku-prebuild and modified heroku-postbuild so that we can still use devDependencies in package json file during development.